### PR TITLE
Disabling smart linkify on Android

### DIFF
--- a/android/src/main/java/com/astrocoders/selectabletext/RNSelectableTextManager.java
+++ b/android/src/main/java/com/astrocoders/selectabletext/RNSelectableTextManager.java
@@ -54,19 +54,17 @@ public class RNSelectableTextManager extends ReactTextViewManager {
             public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
                 // Called when action mode is first created. The menu supplied
                 // will be used to generate action buttons for the action mode
-                menu.removeItem(android.R.id.copy);
-                menu.removeItem(android.R.id.shareText);
-                menu.removeItem(android.R.id.selectAll);
-
-
+                // Android Smart Linkify feature pushes extra options into the menu
+                // and would override the generated menu items
+                menu.clear();
+                for (int i = 0; i < menuItems.length; i++) {
+                  menu.add(0, i, 0, menuItems[i]);
+                }
                 return true;
             }
 
             @Override
             public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-                for (int i = 0; i < menuItems.length; i++) {
-                    menu.add(0, i, 0, menuItems[i]);
-                }
                 return true;
             }
 


### PR DESCRIPTION
Android Smart Linkify pushes extra menuItems into the menu, so the react-native menuItems are going to be overridden. If it is fully cleared, only the items show up that were included as menuItem prop. This disables Android Smart Linkify completely.