### PR TITLE
Allow use of other Text components to render text

### DIFF
--- a/Demo/SelectableText.js
+++ b/Demo/SelectableText.js
@@ -66,11 +66,15 @@ const mapHighlightsRanges = (value, highlights) => {
  * highlights: array({ id, start, end })
  * highlightColor: string
  * onHighlightPress: string => void
+ * textValueProp: string
+ * TextComponent: ReactNode
+ * textComponentProps: object
  */
 export const SelectableText = ({
   onSelection, onHighlightPress, textValueProp, value, TextComponent,
   textComponentProps, ...props
 }) => {
+  const usesTextComponent = !TextComponent;
   TextComponent = TextComponent || Text;
   textValueProp = textValueProp || 'children';  // default to `children` which will render `value` as a child of `TextComponent`
   const onSelectionNative = ({
@@ -97,33 +101,36 @@ export const SelectableText = ({
       : onHighlightPress
     : () => {}
 
-  // TODO: convert Text to TextComponent. User React Children API
-  const textValue = (
-    props.highlights && props.highlights.length > 0
-      ? mapHighlightsRanges(value, props.highlights).map(({ id, isHighlight, text }) => (
-          <Text
-            key={v4()}
-            selectable
-            style={
-              isHighlight
-                ? {
-                    backgroundColor: props.highlightColor,
-                  }
-                : {}
-            }
-            onPress={() => {
-              if (isHighlight) {
-                onHighlightPress && onHighlightPress(id)
+  // highlights feature is only supported if `TextComponent == Text`
+  let textValue = value;
+  if (usesTextComponent) {
+    textValue = (
+      props.highlights && props.highlights.length > 0
+        ? mapHighlightsRanges(value, props.highlights).map(({ id, isHighlight, text }) => (
+            <Text
+              key={v4()}
+              selectable
+              style={
+                isHighlight
+                  ? {
+                      backgroundColor: props.highlightColor,
+                    }
+                  : {}
               }
-            }}
-          >
-            {text}
-          </Text>
-        ))
-    : [value]
-  );
-  if (props.appendToChildren) {
-    textValue.push(props.appendToChildren);
+              onPress={() => {
+                if (isHighlight) {
+                  onHighlightPress && onHighlightPress(id)
+                }
+              }}
+            >
+              {text}
+            </Text>
+          ))
+      : [value]
+    );
+    if (props.appendToChildren) {
+      textValue.push(props.appendToChildren);
+    }
   }
   return (
     <RNSelectableText
@@ -134,8 +141,7 @@ export const SelectableText = ({
     >
       <TextComponent
         key={v4()}
-        textValueProp={textValue}
-        {...textComponentProps}
+        {...{[textValueProp]: textValue, ...textComponentProps}}
       />
     </RNSelectableText>
   )

--- a/Demo/SelectableText.js
+++ b/Demo/SelectableText.js
@@ -67,7 +67,12 @@ const mapHighlightsRanges = (value, highlights) => {
  * highlightColor: string
  * onHighlightPress: string => void
  */
-export const SelectableText = ({ onSelection, onHighlightPress, value, children, ...props }) => {
+export const SelectableText = ({
+  onSelection, onHighlightPress, textValueProp, value, TextComponent,
+  textComponentProps, ...props
+}) => {
+  TextComponent = TextComponent || Text;
+  textValueProp = textValueProp || 'children';  // default to `children` which will render `value` as a child of `TextComponent`
   const onSelectionNative = ({
     nativeEvent: { content, eventType, selectionStart, selectionEnd },
   }) => {
@@ -92,6 +97,34 @@ export const SelectableText = ({ onSelection, onHighlightPress, value, children,
       : onHighlightPress
     : () => {}
 
+  // TODO: convert Text to TextComponent. User React Children API
+  const textValue = (
+    props.highlights && props.highlights.length > 0
+      ? mapHighlightsRanges(value, props.highlights).map(({ id, isHighlight, text }) => (
+          <Text
+            key={v4()}
+            selectable
+            style={
+              isHighlight
+                ? {
+                    backgroundColor: props.highlightColor,
+                  }
+                : {}
+            }
+            onPress={() => {
+              if (isHighlight) {
+                onHighlightPress && onHighlightPress(id)
+              }
+            }}
+          >
+            {text}
+          </Text>
+        ))
+    : [value]
+  );
+  if (props.appendToChildren) {
+    textValue.push(props.appendToChildren);
+  }
   return (
     <RNSelectableText
       {...props}
@@ -99,31 +132,11 @@ export const SelectableText = ({ onSelection, onHighlightPress, value, children,
       selectable
       onSelection={onSelectionNative}
     >
-      <Text selectable key={v4()}>
-        {props.highlights && props.highlights.length > 0
-          ? mapHighlightsRanges(value, props.highlights).map(({ id, isHighlight, text }) => (
-              <Text
-                key={v4()}
-                selectable
-                style={
-                  isHighlight
-                    ? {
-                        backgroundColor: props.highlightColor,
-                      }
-                    : {}
-                }
-                onPress={() => {
-                  if (isHighlight) {
-                    onHighlightPress && onHighlightPress(id)
-                  }
-                }}
-              >
-                {text}
-              </Text>
-            ))
-          : value}
-        {props.appendToChildren ? props.appendToChildren : null}
-      </Text>
+      <TextComponent
+        key={v4()}
+        textValueProp={textValue}
+        {...textComponentProps}
+      />
     </RNSelectableText>
   )
 }

--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ import { SelectableText } from "@astrocoders/react-native-selectable-text";
 | **highlightColor** | highlight color |string | null |
 | **onHighlightPress** | called when the user taps the highlight  |(id: string) => void | () => {} |
 | **appendToChildren** | element to be added in the last line of text | ReactNode | null |
+| **TextComponent** | Text component used to render `value` | ReactNode | <Text> |
+| **textValueProp** | text value prop for TextComponent. Should be used when passing TextComponent. Defaults to 'children' which works for <Text> | string | 'children' |
+| **textComponentProps** | additional props to pass to TextComponent | object | null |
+


### PR DESCRIPTION
I was trying to use this repo in conjunction with a repo which can render HTML (for example [this](https://github.com/archriss/react-native-render-html) one or [this](https://github.com/jsdf/react-native-htmlview) one).

In order to make them work together, I added 3 props to allow users to use an alternative Text component to render the text

1. `TextComponent` - this defaults to `Text`. If passed, this component will render the text
2. `textValueProp` - this is the prop name for the text value to be passed to `TextComponent`. This was necessary because different 3rd party Text components use different names for this prop (e.g. this repo uses `value` while others use `html`). This defaults to `children` which will make `TextComponent` behave like the default Text component.
3. `textComponentProps` - additional props to pass to `TextComponent`

Please tell me if there's anything that should be changed about the PR.

This fixes the following issues: #27 and #29.  